### PR TITLE
feat: parametrize templates more + disable multipart uploads because of memory issues

### DIFF
--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -6,11 +6,11 @@ stringData:
   rclone.conf: |
     [out_s3]
     type = s3
-    provider = Minio
+    provider = {{ .Values.app.out.provider | default "Minio" }}
     access_key_id =  {{ .Values.app.out.s3AccessKey }}
     secret_access_key = {{ .Values.app.out.s3SecretKey }}
-    endpoint = https://restic.itrooz.fr
-    region = us-east-1
+    endpoint = {{ .Values.app.out.endpoint | default "https://restic.itrooz.fr" }}
+    region = {{ .Values.app.out.region | default "us-east-1" }}
 
     [crypt_out_s3]
     type = crypt

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -6,6 +6,7 @@ stringData:
   rclone.conf: |
     [out_s3]
     type = s3
+    use_multipart_uploads = false
     provider = {{ .Values.app.out.provider | default "Minio" }}
     access_key_id =  {{ .Values.app.out.s3AccessKey }}
     secret_access_key = {{ .Values.app.out.s3SecretKey }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -7,11 +7,11 @@ stringData:
     [out_s3]
     type = s3
     use_multipart_uploads = false
-    provider = {{ .Values.app.out.provider | default "Minio" }}
+    provider = {{ .Values.app.out.provider }}
     access_key_id =  {{ .Values.app.out.s3AccessKey }}
     secret_access_key = {{ .Values.app.out.s3SecretKey }}
-    endpoint = {{ .Values.app.out.endpoint | default "https://restic.itrooz.fr" }}
-    region = {{ .Values.app.out.region | default "us-east-1" }}
+    endpoint = {{ .Values.app.out.endpoint }}
+    region = {{ .Values.app.out.region }}
 
     [crypt_out_s3]
     type = crypt

--- a/values.yaml
+++ b/values.yaml
@@ -32,7 +32,7 @@ app:
   # Credentials to authenticate to destination s3 server
   out:
     provider: "Minio"
-    endpoint: "https://restic.itrooz.fr"
+    endpoint: "https://restic.example.com"
     region: "us-east-1"
     bucket_and_prefix: "/server1/k8s"
     s3AccessKey: "user"

--- a/values.yaml
+++ b/values.yaml
@@ -31,6 +31,9 @@ app:
     s3SecretKey: "S3-SECRET-KEY"
   # Credentials to authenticate to destination s3 server
   out:
+    provider: "Minio"
+    endpoint: "https://restic.itrooz.fr"
+    region: "us-east-1"
     bucket_and_prefix: "/server1/k8s"
     s3AccessKey: "user"
     s3SecretKey: "S3-SECRET-KEY"


### PR DESCRIPTION
Hello!

I have parametrized the s3 provider, endpoint and region to allow a configurable implementation. I had choose to use `{{ .Value.value | default entry }}` to do not break existent `values.yaml` neither previous installations.

Also, I added a small recommended fix to s3 serve from https://rclone.org/commands/rclone_serve_s3/#bugs